### PR TITLE
fix(todoWrite): set default priority to medium for todos

### DIFF
--- a/src/converters/claude/index.ts
+++ b/src/converters/claude/index.ts
@@ -284,13 +284,21 @@ function handleTodoWrite(
     }
   }
 
+  const todosWithDefaults = (todos || []).map((todo) => ({
+    ...todo,
+    priority:
+      todo.priority && ["low", "medium", "high"].includes(todo.priority)
+        ? todo.priority
+        : ("medium" as const),
+  }));
+
   const invocation: ToolInvocationUIPart<ClientToolsType["todoWrite"]> = {
     type: "tool-invocation",
     toolInvocation: {
       state: "result",
       toolCallId: c.id,
       toolName,
-      args: { todos: todos || [] },
+      args: { todos: todosWithDefaults },
       result: {
         success,
       },


### PR DESCRIPTION
Ensure todos without a valid priority value default to "medium" when writing. This prevents potential errors from undefined or invalid priority values.