### PR TITLE
fix(claude): add default id for todos in todoWrite handler

### DIFF
--- a/src/providers/claude/convert-messages.ts
+++ b/src/providers/claude/convert-messages.ts
@@ -264,8 +264,9 @@ function handleTodoWrite(
   toolResultItem: ClaudeCodeMessage | null,
 ): UIToolPart<"todoWrite"> {
   const { todos } = c.input as TodoWriteToolInput;
-  const todosWithDefaults = (todos || []).map((todo) => ({
+  const todosWithDefaults = (todos || []).map((todo, index) => ({
     ...todo,
+    id: todo.id || `todo-${index}`,
     priority:
       todo.priority && ["low", "medium", "high"].includes(todo.priority)
         ? todo.priority


### PR DESCRIPTION
## Summary:

Claude code currently remove id from each todo we need to ensure each todo item has a unique identifier by providing a default id when none is specified

